### PR TITLE
docs: publish v1.0.3 verification metadata

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -48,16 +48,16 @@ The current release includes general, General ALT, YouTube, Discord, Simple Fake
 
 ## Release verification
 
-The corrected `v1.0.2` Windows asset is a genuine ZIP archive with Windows CRLF line endings for BAT/CMD files and Zapret2 profiles:
+The corrected `v1.0.3` Windows asset is a genuine ZIP archive with Windows CRLF line endings for BAT/CMD files and Zapret2 profiles:
 
 | Version | Asset | SHA-256 | VirusTotal |
 | --- | --- | --- | --- |
-| v1.0.2 | `zapret2-youtube-discord-v1.0.2.zip` | `8b1ca630a86ba3bf9a2cb5a90e5eca980d62d0ce1c7f64ac9e524687a7d41652` | [Open report](https://www.virustotal.com/gui/file/8b1ca630a86ba3bf9a2cb5a90e5eca980d62d0ce1c7f64ac9e524687a7d41652) |
+| v1.0.3 | `zapret2-youtube-discord-v1.0.3.zip` | `b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b` | [Open report](https://www.virustotal.com/gui/file/b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b) |
 
 Check the downloaded file in PowerShell:
 
 ```powershell
-Get-FileHash .\zapret2-youtube-discord-v1.0.2.zip -Algorithm SHA256
+Get-FileHash .\zapret2-youtube-discord-v1.0.3.zip -Algorithm SHA256
 ```
 
 Verify the signed checksum manifest:
@@ -74,14 +74,14 @@ When a GitHub Release is published, `.github/workflows/release-security.yml` dow
 
 The project is also published in [goshkow's Zapret Hub Marketplace](https://goshkow.com/zapret-hub/marketplace/projects/https_github_com_klondike0x_zapret2_youtube_discor). Its listing has `published` status and passed the marketplace moderation process. This is an additional independent publication check, not a replacement for the exact release SHA-256, GPG signature, or VirusTotal report.
 
-The `v1.0.0` asset was mistakenly packaged as TAR under a `.zip` extension. The `v1.0.1` ZIP contained LF line endings in Windows scripts and profiles. Both have been superseded by `v1.0.2`.
+The `v1.0.0` asset was mistakenly packaged as TAR under a `.zip` extension. The `v1.0.1` ZIP contained LF line endings in Windows scripts and profiles. Both have been superseded by `v1.0.3`.
 
 ## Reproducing the ZIP
 
 The release ZIP builder exports tracked files from a Git revision and writes a deterministic ZIP layout:
 
 ```bash
-python tools/build_release_zip.py --version v1.0.2 --revision v1.0.2 --output-dir dist
+python tools/build_release_zip.py --version v1.0.3 --revision v1.0.3 --output-dir dist
 python tests/validate_release_zip.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ GPG fingerprint релизов: `4001 5491 B3A6 3D77 7855 FEC0 8DA8 2B54 BDED 31
 
 Каждый отчёт VirusTotal относится **только к конкретному файлу с конкретным SHA-256**. Если архив был пересобран или изменён хотя бы на один байт, старый отчёт к нему больше не относится.
 
-[![VirusTotal](https://img.shields.io/badge/VirusTotal-отчёт_v1.0.2-394EFF?logo=virustotal&logoColor=white)](https://www.virustotal.com/gui/file/8b1ca630a86ba3bf9a2cb5a90e5eca980d62d0ce1c7f64ac9e524687a7d41652)
+[![VirusTotal](https://img.shields.io/badge/VirusTotal-отчёт_v1.0.3-394EFF?logo=virustotal&logoColor=white)](https://www.virustotal.com/gui/file/b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b)
 
 | Версия | Файл | SHA-256 | VirusTotal |
 | --- | --- | --- | --- |
-| v1.0.2 | `zapret2-youtube-discord-v1.0.2.zip` | `8b1ca630a86ba3bf9a2cb5a90e5eca980d62d0ce1c7f64ac9e524687a7d41652` | [Открыть отчёт](https://www.virustotal.com/gui/file/8b1ca630a86ba3bf9a2cb5a90e5eca980d62d0ce1c7f64ac9e524687a7d41652) |
+| v1.0.3 | `zapret2-youtube-discord-v1.0.3.zip` | `b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b` | [Открыть отчёт](https://www.virustotal.com/gui/file/b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b) |
 
 SHA-256 выше получен непосредственно из метаданных GitHub Release asset. Перед запуском рекомендуется сравнить хеш скачанного архива:
 
 ```powershell
-Get-FileHash .\zapret2-youtube-discord-v1.0.2.zip -Algorithm SHA256
+Get-FileHash .\zapret2-youtube-discord-v1.0.3.zip -Algorithm SHA256
 ```
 
 Проверка GPG-подписи опубликованного манифеста:
@@ -71,14 +71,14 @@ python tools/generate_virustotal_table.py dist/<архив> --version vX.Y.Z
 Portable ZIP собирается из файлов конкретного Git-коммита, а не из произвольного содержимого рабочей папки:
 
 ```bash
-python tools/build_release_zip.py --version v1.0.2 --revision v1.0.2 --output-dir dist
+python tools/build_release_zip.py --version v1.0.3 --revision v1.0.3 --output-dir dist
 python tests/validate_release_zip.py
 ```
 
 Workflow `Build verification` запускает проверки, собирает настоящий ZIP и для запусков в публичном репозитории вне pull request публикует GitHub artifact attestation. Attestation связывает полученный архив с репозиторием, workflow и коммитом. Она дополняет, но не заменяет подписанные `SHA256SUMS.txt` и `SHA256SUMS.txt.asc` в официальном релизе.
 
 > [!IMPORTANT]
-> Архив `zapret2-youtube-discord-v1.0.0.zip` был ошибочно создан в формате TAR при расширении `.zip`, а в `v1.0.1` BAT-файлы и профили попали в ZIP с переносами LF. Для Windows используйте `v1.0.2` или новее. Формат ZIP, целостность и CRLF теперь проверяются автоматически перед публикацией.
+> Архив `zapret2-youtube-discord-v1.0.0.zip` был ошибочно создан в формате TAR при расширении `.zip`, а в `v1.0.1` BAT-файлы и профили попали в ZIP с переносами LF. Для Windows используйте `v1.0.3` или новее. Формат ZIP, целостность и CRLF теперь проверяются автоматически перед публикацией.
 
 ## 🚀 Быстрый запуск
 

--- a/tests/validate_security_metadata.py
+++ b/tests/validate_security_metadata.py
@@ -8,8 +8,8 @@ import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-RELEASE_HASH = "8b1ca630a86ba3bf9a2cb5a90e5eca980d62d0ce1c7f64ac9e524687a7d41652"
-RELEASE_VERSION = "v1.0.2"
+RELEASE_HASH = "b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b"
+RELEASE_VERSION = "v1.0.3"
 
 
 def main() -> int:

--- a/tests/validate_trust_docs.py
+++ b/tests/validate_trust_docs.py
@@ -25,9 +25,9 @@ def main() -> int:
         "actions/workflows/build-verification.yml/badge.svg",
         "github/v/release/klondike0x/zapret2-youtube-discord",
         "github/downloads/klondike0x/zapret2-youtube-discord/total",
-        "8b1ca630a86ba3bf9a2cb5a90e5eca980d62d0ce1c7f64ac9e524687a7d41652",
-        "https://www.virustotal.com/gui/file/8b1ca630a86ba3bf9a2cb5a90e5eca980d62d0ce1c7f64ac9e524687a7d41652",
-        "v1.0.2",
+        "b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b",
+        "https://www.virustotal.com/gui/file/b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b",
+        "v1.0.3",
         "goshkow.com/zapret-hub/marketplace/projects/https_github_com_klondike0x_zapret2_youtube_discor",
         "Zapret Hub Marketplace",
     ]:
@@ -38,7 +38,7 @@ def main() -> int:
     for token in [
         "README.md",
         "winws2.exe v1.0.3",
-        "v1.0.2",
+        "v1.0.3",
         "4001 5491 B3A6 3D77 7855 FEC0 8DA8 2B54 BDED 31AE",
         "VirusTotal",
         "NOTICE",


### PR DESCRIPTION
## Что обновлено

• SHA-256 официального ZIP v1.0.3
• ссылка на завершённый анализ VirusTotal
• команды проверки и воспроизводимой сборки
• синхронные данные в README.md и README.en.md
• контрактные проверки публичных метаданных

## Проверка

• опубликованный ZIP повторно скачан с GitHub
• ZIP signature и CRC проверены
• SHA-256: b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b
• GPG подпись SHA256SUMS.txt проверена
• validate_security_metadata.py
• validate_trust_docs.py
• validate_project.py

Release: https://github.com/klondike0x/zapret2-youtube-discord/releases/tag/v1.0.3
VirusTotal: https://www.virustotal.com/gui/file/b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b