### PR TITLE
fix: remove services with unquoted ImagePath

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -27,15 +27,18 @@ jobs:
 
       - name: Run maintained validators
         shell: cmd
+        env:
+          PYTHONUTF8: 1
         run: |
-          python tests\validate_project.py
-          python tests\validate_service_manager.py
-          python tests\validate_flowseal_alt_port.py
-          python tests\validate_strategy_variants.py
-          python tests\validate_release_zip.py
-          python tests\validate_security_metadata.py
-          python tests\validate_trust_docs.py
-          python tests\validate_virustotal_upload.py
+          python tests\validate_project.py || exit /b 1
+          python tests\validate_service_manager.py || exit /b 1
+          powershell -NoProfile -ExecutionPolicy Bypass -File tests\validate_service_imagepath.ps1 || exit /b 1
+          python tests\validate_flowseal_alt_port.py || exit /b 1
+          python tests\validate_strategy_variants.py || exit /b 1
+          python tests\validate_release_zip.py || exit /b 1
+          python tests\validate_security_metadata.py || exit /b 1
+          python tests\validate_trust_docs.py || exit /b 1
+          python tests\validate_virustotal_upload.py || exit /b 1
 
   build-zip:
     name: Build genuine ZIP

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,14 +55,18 @@ jobs:
 
       - name: Run maintained validators
         shell: cmd
+        env:
+          PYTHONUTF8: 1
         run: |
-          python tests\validate_project.py
-          python tests\validate_flowseal_alt_port.py
-          python tests\validate_strategy_variants.py
-          python tests\validate_release_zip.py
-          python tests\validate_security_metadata.py
-          python tests\validate_trust_docs.py
-          python tests\validate_virustotal_upload.py
+          python tests\validate_project.py || exit /b 1
+          python tests\validate_service_manager.py || exit /b 1
+          powershell -NoProfile -ExecutionPolicy Bypass -File tests\validate_service_imagepath.ps1 || exit /b 1
+          python tests\validate_flowseal_alt_port.py || exit /b 1
+          python tests\validate_strategy_variants.py || exit /b 1
+          python tests\validate_release_zip.py || exit /b 1
+          python tests\validate_security_metadata.py || exit /b 1
+          python tests\validate_trust_docs.py || exit /b 1
+          python tests\validate_virustotal_upload.py || exit /b 1
 
       - name: Build deterministic Windows ZIP from exact tag
         shell: pwsh

--- a/service.bat
+++ b/service.bat
@@ -161,7 +161,7 @@ goto menu
 cls
 set "STOPPED_MANUAL=0"
 for /f "delims=" %%N in ('"%POWERSHELL%" -NoProfile -ExecutionPolicy Bypass -File "%~dp0tools\stop-manual-winws2.ps1" 2^>nul') do set "STOPPED_MANUAL=%%N"
-if "%STOPPED_MANUAL%"=="0" (echo No manual winws2.exe from this bundle is running.) else (echo Stopped %STOPPED_MANUAL% manual winws2.exe process(es).)
+if "%STOPPED_MANUAL%"=="0" (echo No manual winws2.exe from this bundle is running.) else (echo Stopped %STOPPED_MANUAL% manual winws2.exe processes.)
 pause
 goto menu
 

--- a/tests/validate_service_imagepath.ps1
+++ b/tests/validate_service_imagepath.ps1
@@ -1,0 +1,71 @@
+$ErrorActionPreference = 'Stop'
+
+$root = Split-Path -Parent $PSScriptRoot
+$controlPath = Join-Path $root 'tools\service-control.ps1'
+$tokens = $null
+$errors = $null
+$ast = [Management.Automation.Language.Parser]::ParseFile($controlPath, [ref]$tokens, [ref]$errors)
+if ($errors.Count) { throw ($errors | ForEach-Object Message | Out-String) }
+
+foreach ($name in @('Get-ImageExecutable', 'Get-ServiceConfigPath', 'Assert-CurrentOwner')) {
+    $functionAst = $ast.Find({
+        param($node)
+        $node -is [Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name
+    }, $true)
+    if (-not $functionAst) { throw "Function not found: $name" }
+    Invoke-Expression $functionAst.Extent.Text
+}
+
+$exe = 'C:\zapret\bundle\bin\winws2.exe'
+$config = 'C:\zapret\bundle\tools\service-active.txt'
+$cases = @(
+    ('"{0}" @"{1}"' -f $exe, $config),
+    ('{0} @{1}' -f $exe, $config),
+    ('"{0}" @{1}' -f $exe, $config),
+    ('{0} @"{1}"' -f $exe, $config)
+)
+
+foreach ($imagePath in $cases) {
+    $actualExe = Get-ImageExecutable $imagePath
+    $actualConfig = Get-ServiceConfigPath $imagePath
+    if (-not $actualExe.Equals($exe, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Executable parse failed: $imagePath -> $actualExe"
+    }
+    if (-not $actualConfig.Equals($config, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Config parse failed: $imagePath -> $actualConfig"
+    }
+}
+
+foreach ($invalid in @(
+    'C:\other\winws2.exe',
+    'C:\other\winws2.exe --wrong',
+    'C:\other\winws2.exe @C:\config.txt extra'
+)) {
+    if (Get-ServiceConfigPath $invalid) { throw "Invalid ImagePath accepted: $invalid" }
+}
+
+$activeFull = $config
+foreach ($imagePath in $cases) {
+    Assert-CurrentOwner ([PSCustomObject]@{ PathName = $imagePath })
+}
+
+$foreignCases = @(
+    ('C:\other\winws2.exe @{0}' -f $config),
+    ('{0} @C:\other\service-active.txt' -f $exe),
+    ('C:\other\winws2.exe @C:\other\service-active.txt')
+)
+foreach ($imagePath in $foreignCases) {
+    $rejected = $false
+    try {
+        Assert-CurrentOwner ([PSCustomObject]@{ PathName = $imagePath })
+    } catch {
+        if ($_.Exception.Message -like 'Refusing to manage winws2 owned by another installation:*') {
+            $rejected = $true
+        } else {
+            throw
+        }
+    }
+    if (-not $rejected) { throw "Foreign service ownership accepted: $imagePath" }
+}
+
+Write-Output 'PASS quoted and unquoted winws2 ImagePath parsing with exact ownership rejection'

--- a/tests/validate_service_manager.py
+++ b/tests/validate_service_manager.py
@@ -9,6 +9,9 @@ SERVICE = ROOT / "service.bat"
 CONTROL = ROOT / "tools" / "service-control.ps1"
 PREPARE = ROOT / "tools" / "prepare-service-profile.ps1"
 STRATEGY_TEST = ROOT / "tools" / "test-strategies.ps1"
+IMAGEPATH_TEST = ROOT / "tests" / "validate_service_imagepath.ps1"
+BUILD_WORKFLOW = ROOT / ".github" / "workflows" / "build-verification.yml"
+PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish-release.yml"
 
 
 def fail(message: str) -> None:
@@ -124,6 +127,8 @@ def main() -> int:
 
     if not CONTROL.is_file():
         fail("отсутствует tools/service-control.ps1")
+    if not IMAGEPATH_TEST.is_file():
+        fail("отсутствует tests/validate_service_imagepath.ps1")
     control = CONTROL.read_text(encoding="utf-8-sig")
     for token in [
         "$serviceName = 'winws2'",
@@ -174,6 +179,34 @@ def main() -> int:
         require(control, token, "exact legacy ownership")
     for token in ["'Disabled' { 'disabled' }", "Rollback incomplete", "legacy cleanup failed", "$LASTEXITCODE -ne 0", "$installError", "Failed to update service description"]:
         require(control, token, "transaction rollback")
+
+    imagepath_probe = subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(IMAGEPATH_TEST),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
+    )
+    if imagepath_probe.returncode != 0 or "PASS quoted and unquoted" not in imagepath_probe.stdout:
+        fail(f"разбор ImagePath завершился ошибкой: {(imagepath_probe.stdout + imagepath_probe.stderr).strip()}")
+
+    for workflow_path in [BUILD_WORKFLOW, PUBLISH_WORKFLOW]:
+        workflow = workflow_path.read_text(encoding="utf-8-sig")
+        if "PYTHONUTF8: 1" not in workflow:
+            fail(f"{workflow_path.name}: Python UTF-8 mode is not enabled")
+        for line in workflow.splitlines():
+            command = line.strip()
+            if command.startswith(("python tests\\", "powershell -NoProfile")) and "|| exit /b 1" not in command:
+                fail(f"{workflow_path.name}: validator is not fail-fast: {command}")
 
     prepare = PREPARE.read_text(encoding="utf-8-sig")
     for token in ["--chdir=", "WriteAllText", "ProfilePath", "service-active.txt"]:

--- a/tests/validate_service_manager.py
+++ b/tests/validate_service_manager.py
@@ -169,6 +169,9 @@ def main() -> int:
         fail("legacy ownership должен перепроверяться непосредственно перед stop/delete")
     if "echo Profile not found: %PROFILE_PATH%" in service:
         fail("elevated BAT не должен интерпретировать путь как часть команды echo")
+    if "process(es)." in service:
+        fail("CMD block must not contain an unescaped closing parenthesis in status text")
+    require(service, "manual winws2.exe processes.", "manual process status")
     if "Remove-LegacyIfOwned" not in control or "$expectedScript" not in control:
         fail("legacy service удаляется без проверки владельца")
     if "IndexOf($expectedScript" in control or ".Contains($expectedScript" in control:

--- a/tools/service-control.ps1
+++ b/tools/service-control.ps1
@@ -42,9 +42,12 @@ function Get-ImageExecutable([string]$ImagePath) {
 function Get-ServiceConfigPath([string]$ImagePath) {
     if (-not $ImagePath) { return $null }
     $expanded = [Environment]::ExpandEnvironmentVariables($ImagePath).Trim()
-    $match = [Regex]::Match($expanded, '^\s*"[^"]+"\s+@"([^"]+)"\s*$')
+    $match = [Regex]::Match(
+        $expanded,
+        '^\s*(?:"[^"]+"|[^\s"]+)\s+@(?:"(?<config>[^"]+)"|(?<config>[^\s"]+))\s*$'
+    )
     if (-not $match.Success) { return $null }
-    try { return [IO.Path]::GetFullPath($match.Groups[1].Value) } catch { return $null }
+    try { return [IO.Path]::GetFullPath($match.Groups['config'].Value) } catch { return $null }
 }
 
 function Assert-CurrentOwner([object]$Service) {


### PR DESCRIPTION
## Что исправлено

• `service-control.ps1` распознаёт SCM `ImagePath` с кавычками и без них
• сохраняется точное сравнение пути `winws2.exe` и `service-active.txt`
• чужой executable или config по прежнему отклоняется
• исправлено аварийное закрытие `service.bat` в пункте `Stop manual winws2.exe from this bundle`
• добавлен поведенческий PowerShell тест четырёх допустимых форматов и трёх чужих вариантов
• валидаторы в build и release workflow завершают шаг сразу при первой ошибке
• для Python проверок в Windows CI включён UTF-8

## Проверка

• воспроизведён пользовательский формат `ImagePath` без кавычек
• штатный `Remove` успешно удалил тестовую службу
• подтверждён SCM error 1060 после удаления
• пункт 6 запущен через настоящий `service.bat`, показал сообщение, дождался нажатия клавиши и вернулся в меню
• runtime файлы очищены
• полный набор локальных валидаторов прошёл
• независимый review: PASS, Blocker и High отсутствуют

Связано с #1
