### PR TITLE
fix: show the correct service manager version

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -1,5 +1,5 @@
 @echo off
-set "LOCAL_VERSION=2.0.2"
+set "LOCAL_VERSION=1.0.4"
 set "SERVICE_CONTROL=%~dp0tools\service-control.ps1"
 set "POWERSHELL=C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
 set "COMSPEC_TRUSTED=C:\Windows\System32\cmd.exe"

--- a/tests/validate_service_manager.py
+++ b/tests/validate_service_manager.py
@@ -25,6 +25,9 @@ def require(text: str, token: str, label: str) -> None:
 
 def main() -> int:
     service = SERVICE.read_text(encoding="utf-8-sig")
+    require(service, 'set "LOCAL_VERSION=1.0.4"', "service manager version")
+    if 'set "LOCAL_VERSION=2.0.2"' in service:
+        fail("service.bat не должен показывать версию стороннего service manager")
     for token in [
         "service-control.ps1",
         "-Action Install",


### PR DESCRIPTION
## Что исправлено

- заменена ошибочная версия service manager `v2.0.2` на версию следующего релиза `v1.0.4`
- добавлена регрессионная проверка версии в валидатор service manager

## Проверка

- `python tests/validate_service_manager.py`
- `python tests/validate_project.py`
- `git diff --check`