### PR TITLE
docs: publish v1.0.4 verification metadata

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -52,12 +52,13 @@ The corrected `v1.0.3` Windows asset is a genuine ZIP archive with Windows CRLF 
 
 | Version | Asset | SHA-256 | VirusTotal |
 | --- | --- | --- | --- |
+| v1.0.4 | `zapret2-youtube-discord-v1.0.4.zip` | `2050ce15779b3595cec7320e664fa66f4ba517e978df6bd97b040803cda38535` | [Open report](https://www.virustotal.com/gui/file/2050ce15779b3595cec7320e664fa66f4ba517e978df6bd97b040803cda38535) |
 | v1.0.3 | `zapret2-youtube-discord-v1.0.3.zip` | `b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b` | [Open report](https://www.virustotal.com/gui/file/b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b) |
 
 Check the downloaded file in PowerShell:
 
 ```powershell
-Get-FileHash .\zapret2-youtube-discord-v1.0.3.zip -Algorithm SHA256
+Get-FileHash .\zapret2-youtube-discord-v1.0.4.zip -Algorithm SHA256
 ```
 
 Verify the signed checksum manifest:
@@ -74,14 +75,14 @@ When a GitHub Release is published, `.github/workflows/release-security.yml` dow
 
 The project is also published in [goshkow's Zapret Hub Marketplace](https://goshkow.com/zapret-hub/marketplace/projects/https_github_com_klondike0x_zapret2_youtube_discor). Its listing has `published` status and passed the marketplace moderation process. This is an additional independent publication check, not a replacement for the exact release SHA-256, GPG signature, or VirusTotal report.
 
-The `v1.0.0` asset was mistakenly packaged as TAR under a `.zip` extension. The `v1.0.1` ZIP contained LF line endings in Windows scripts and profiles. Both have been superseded by `v1.0.3`.
+The `v1.0.0` asset was mistakenly packaged as TAR under a `.zip` extension. The `v1.0.1` ZIP contained LF line endings in Windows scripts and profiles. Both have been superseded by `v1.0.4`.
 
 ## Reproducing the ZIP
 
 The release ZIP builder exports tracked files from a Git revision and writes a deterministic ZIP layout:
 
 ```bash
-python tools/build_release_zip.py --version v1.0.3 --revision v1.0.3 --output-dir dist
+python tools/build_release_zip.py --version v1.0.4 --revision v1.0.4 --output-dir dist
 python tests/validate_release_zip.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,16 +30,17 @@ GPG fingerprint релизов: `4001 5491 B3A6 3D77 7855 FEC0 8DA8 2B54 BDED 31
 
 Каждый отчёт VirusTotal относится **только к конкретному файлу с конкретным SHA-256**. Если архив был пересобран или изменён хотя бы на один байт, старый отчёт к нему больше не относится.
 
-[![VirusTotal](https://img.shields.io/badge/VirusTotal-отчёт_v1.0.3-394EFF?logo=virustotal&logoColor=white)](https://www.virustotal.com/gui/file/b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b)
+[![VirusTotal](https://img.shields.io/badge/VirusTotal-отчёт_v1.0.4-394EFF?logo=virustotal&logoColor=white)](https://www.virustotal.com/gui/file/2050ce15779b3595cec7320e664fa66f4ba517e978df6bd97b040803cda38535)
 
 | Версия | Файл | SHA-256 | VirusTotal |
 | --- | --- | --- | --- |
+| v1.0.4 | `zapret2-youtube-discord-v1.0.4.zip` | `2050ce15779b3595cec7320e664fa66f4ba517e978df6bd97b040803cda38535` | [Открыть отчёт](https://www.virustotal.com/gui/file/2050ce15779b3595cec7320e664fa66f4ba517e978df6bd97b040803cda38535) |
 | v1.0.3 | `zapret2-youtube-discord-v1.0.3.zip` | `b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b` | [Открыть отчёт](https://www.virustotal.com/gui/file/b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b) |
 
 SHA-256 выше получен непосредственно из метаданных GitHub Release asset. Перед запуском рекомендуется сравнить хеш скачанного архива:
 
 ```powershell
-Get-FileHash .\zapret2-youtube-discord-v1.0.3.zip -Algorithm SHA256
+Get-FileHash .\zapret2-youtube-discord-v1.0.4.zip -Algorithm SHA256
 ```
 
 Проверка GPG-подписи опубликованного манифеста:
@@ -71,7 +72,7 @@ python tools/generate_virustotal_table.py dist/<архив> --version vX.Y.Z
 Portable ZIP собирается из файлов конкретного Git-коммита, а не из произвольного содержимого рабочей папки:
 
 ```bash
-python tools/build_release_zip.py --version v1.0.3 --revision v1.0.3 --output-dir dist
+python tools/build_release_zip.py --version v1.0.4 --revision v1.0.4 --output-dir dist
 python tests/validate_release_zip.py
 ```
 

--- a/tests/validate_security_metadata.py
+++ b/tests/validate_security_metadata.py
@@ -8,8 +8,8 @@ import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-RELEASE_HASH = "b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b"
-RELEASE_VERSION = "v1.0.3"
+RELEASE_HASH = "2050ce15779b3595cec7320e664fa66f4ba517e978df6bd97b040803cda38535"
+RELEASE_VERSION = "v1.0.4"
 
 
 def main() -> int:

--- a/tests/validate_trust_docs.py
+++ b/tests/validate_trust_docs.py
@@ -26,8 +26,8 @@ def main() -> int:
         "github/v/release/klondike0x/zapret2-youtube-discord",
         "github/downloads/klondike0x/zapret2-youtube-discord/total",
         "b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b",
-        "https://www.virustotal.com/gui/file/b5d6ed32f52a96a5ea3542d4da3bc491b9e730cccb87217332f6ae71a1cd048b",
-        "v1.0.3",
+        "2050ce15779b3595cec7320e664fa66f4ba517e978df6bd97b040803cda38535",
+        "v1.0.4",
         "goshkow.com/zapret-hub/marketplace/projects/https_github_com_klondike0x_zapret2_youtube_discor",
         "Zapret Hub Marketplace",
     ]:
@@ -39,6 +39,7 @@ def main() -> int:
         "README.md",
         "winws2.exe v1.0.3",
         "v1.0.3",
+        "v1.0.4",
         "4001 5491 B3A6 3D77 7855 FEC0 8DA8 2B54 BDED 31AE",
         "VirusTotal",
         "NOTICE",


### PR DESCRIPTION
Обновлены RU и EN README, а также валидаторы под новый релиз v1.0.4.

- таблица SHA-256 и VirusTotal
- бейдж
- примеры команд
- ссылки на сборку ZIP
- проверка новой версии в тестах