### PR TITLE
fix: clean up WinDivert driver when removing service

### DIFF
--- a/tests/validate_service_manager.py
+++ b/tests/validate_service_manager.py
@@ -192,6 +192,12 @@ def main() -> int:
         "Service manager is already running",
         "Assert-ServiceStillOwned",
         "Assert-LegacyStillOwned",
+        "Remove-WinDivertDriver",
+        "Stop-TestEngines",
+        "sc stop WinDivert",
+        "sc delete WinDivert",
+        "Failed to stop WinDivert driver",
+        "WinDivert driver was not fully removed",
     ]:
         require(control, token, "service-control.ps1")
     if "IndexOf($exe" in control or "findstr" in control.lower():

--- a/tools/service-control.ps1
+++ b/tools/service-control.ps1
@@ -141,6 +141,44 @@ function Remove-LegacyIfOwned {
     Wait-ServiceState $legacyServiceName 'Absent'
 }
 
+function Remove-WinDivertDriver {
+    $wdf = Get-ServiceRecord 'WinDivert'
+    if (-not $wdf) { return }
+    try {
+        if ($wdf.State -eq 'Running') {
+            & $sc stop WinDivert | Out-Null
+            Wait-ServiceState 'WinDivert' 'Stopped' 10
+        }
+    } catch {
+        Write-Warning "Failed to stop WinDivert driver. It may be held by another process."
+    }
+    try {
+        & $sc delete WinDivert | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "sc delete WinDivert returned code $LASTEXITCODE" }
+        Wait-ServiceState 'WinDivert' 'Absent' 10
+    } catch {
+        Write-Warning "WinDivert driver was not fully removed: $_"
+    }
+}
+
+function Stop-TestEngines {
+    $bundleExeNormalized = $exe.Replace('\', '\\')
+    try {
+        @(Get-CimInstance Win32_Process -Filter "Name='winws2.exe'" -ErrorAction SilentlyContinue | Where-Object {
+            $_.ExecutablePath -and $_.ExecutablePath.Replace('\', '\\').StartsWith($bundleExeNormalized, [StringComparison]::OrdinalIgnoreCase)
+        }) | ForEach-Object {
+            try {
+                Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+                Write-Warning "Stopped a running winws2.exe (PID $($_.ProcessId)) from this bundle before removing the service."
+            } catch {
+                Write-Warning "Failed to stop winws2.exe PID $($_.ProcessId): $_"
+            }
+        }
+    } catch {
+        Write-Warning "Could not inventory running winws2 processes: $_"
+    }
+}
+
 function Install-Profile {
     if (-not $ProfilePath -or -not $ProfileRelative) { throw 'ProfilePath and ProfileRelative are required.' }
     $existing = Get-ServiceRecord $serviceName
@@ -269,6 +307,8 @@ switch ($Action) {
             if ($LASTEXITCODE -ne 0) { throw 'Failed to delete service.' }
             Wait-ServiceState $serviceName 'Absent'
         }
+        Remove-WinDivertDriver
+        Stop-TestEngines
         Remove-Item -LiteralPath $active, $next, $backup -Force -ErrorAction SilentlyContinue
         Remove-LegacyIfOwned
         Write-Output 'Service removed.'


### PR DESCRIPTION
## Что исправлено

При удалении службы winws2 (пункт 2 в service.bat) драйвер WinDivert иногда оставался активным. Это мешало повторной установке и требовало ручного вмешательства.

Теперь  при Remove:

- останавливает и удаляет драйвер WinDivert (
¬ï_á«㦡ë: windivert 
        ¨¯                : 1  KERNEL_DRIVER  
        ®áâ®ﭨ¥          : 3  STOP_PENDING 
                                (STOPPABLE, NOT_PAUSABLE, IGNORES_SHUTDOWN)
        ®¤_¢ë室 _Win32   : 0  (0x0)
        ®¤_¢ë室 _á«㦡ë  : 0  (0x0)
        ®­â஫쭠ï_â®窠  : 0x0
        ¦¨¤ ­¨¥           : 0x0 + [SC] DeleteService: ®訡ª : 1072:

ª § ­­ ï á«㦡  ¡뫠 ®⬥祭  ¤«ï 㤠«¥­¨ï.)
- проверяет и принудительно завершает оставшиеся процессы  из текущего bundle
- ошибки при отсутствии драйвера корректно игнорируются

## Что изменено

- : добавлены функции  и , вызываются в блоке Remove
- : добавлены проверки новых функций

## Проверка

- полный набор локальных валидаторов
- PowerShell syntax check
- 