### PR TITLE
fix: interactive target UX: null-safe input, exit keywords, empty-target guard

### DIFF
--- a/tests/validate_service_manager.py
+++ b/tests/validate_service_manager.py
@@ -125,8 +125,19 @@ def main() -> int:
         "Read-SavedStrategyTargets -Path $targetsFile",
         "Unable to configure test targets",
         "if ($SelfTest) { exit $Code }",
+        "No targets selected. Test cancelled.",
     ]:
         require(strategy_test, token, "tools/test-strategies.ps1")
+
+    targets_lib = TARGETS_LIBRARY.read_text(encoding="utf-8-sig")
+    for token in [
+        "blank or 0 to finish",
+        "No targets added. Test cancelled.",
+        "$null -eq $rawName",
+        "$null -eq $rawValue",
+        "Value cannot be empty. Skipping this target.",
+    ]:
+        require(targets_lib, token, "tools/strategy-targets.ps1")
 
     targets_probe = subprocess.run(
         [

--- a/tools/strategy-targets.ps1
+++ b/tools/strategy-targets.ps1
@@ -137,11 +137,22 @@ function Read-NewStrategyTargets {
         [array]$InitialTargets = @()
     )
 
+    Write-Host 'Enter target name and URL/hostname one at a time.' -ForegroundColor Gray
+    Write-Host 'Leave the name blank or type 0 to finish.' -ForegroundColor Gray
+
     $targets = @($InitialTargets)
     while ($true) {
-        $name = (& $ReadInput 'Target name (blank to finish)').Trim()
-        if (-not $name) { break }
-        $value = (& $ReadInput 'Full http(s) URL or PING:hostname').Trim()
+        $rawName = & $ReadInput 'Target name (blank or 0 to finish)'
+        if ($null -eq $rawName) { $rawName = '' }
+        $name = $rawName.Trim()
+        if (-not $name -or $name -eq '0' -or $name -eq 'exit') { break }
+        $rawValue = & $ReadInput 'Full http(s) URL or PING:hostname'
+        if ($null -eq $rawValue) { $rawValue = '' }
+        $value = $rawValue.Trim()
+        if (-not $value) {
+            Write-Host 'Value cannot be empty. Skipping this target.' -ForegroundColor Yellow
+            continue
+        }
         try {
             $newTarget = ConvertTo-StrategyTarget -Name $name -Value $value
             $targets = @($targets | Where-Object { -not $_.Name.Equals($newTarget.Name, [StringComparison]::OrdinalIgnoreCase) }) + @($newTarget)
@@ -191,7 +202,11 @@ function Select-StrategyTargets {
         if ($choice -eq '1') { return @(Complete-StrategyTargetSelection -Targets @(Get-DefaultStrategyTargets)) }
         if ($choice -eq '2') {
             $temporary = @(Read-NewStrategyTargets -ReadInput $ReadInput -InitialTargets @(Get-DefaultStrategyTargets))
-            if ($temporary.Count -gt 0) { return @(Complete-StrategyTargetSelection -Targets $temporary) }
+            if ($temporary.Count -eq 0) {
+                Write-Host 'No targets added. Test cancelled.' -ForegroundColor Yellow
+                return @()
+            }
+            return @(Complete-StrategyTargetSelection -Targets $temporary)
         } elseif ($choice -eq '3') {
             if ($saved.Count -eq 0) { Write-Host 'No saved targets. Add targets first.' -ForegroundColor Yellow; if ($NonInteractive) { throw 'No saved targets.' }; continue }
             Show-StrategyTargets $saved

--- a/tools/test-strategies.ps1
+++ b/tools/test-strategies.ps1
@@ -246,10 +246,16 @@ if ((Get-RunningWinws2).Count -gt 0) {
 $selected = @(Read-ProfileSelection -Profiles $profiles)
 try {
     $targets = @(Select-StrategyTargets -Path $targetsFile)
-} catch {
-    Exit-WithMessage ("[ERROR] Unable to configure test targets: {0}" -f $_.Exception.Message)
-}
-New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+    } catch {
+        Exit-WithMessage ("[ERROR] Unable to configure test targets: {0}" -f $_.Exception.Message)
+    }
+    if ($targets.Count -eq 0) {
+        Write-Host '[ERROR] No targets selected. Test cancelled.' -ForegroundColor Red
+        Write-Host 'Press any key to close...'
+        [void][Console]::ReadKey($true)
+        exit 1
+    }
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
 $global = @()
 $proc = $null
 $runAborted = $false


### PR DESCRIPTION
## Что исправлено

Пользователи сообщали о проблемах с интерактивной настройкой целей тестов:

- **Выход из цикла добавления целей**: теперь работают пустая строка,  и , добавлены подсказки
- **Ошибка **: добавлена проверка  и  перед вызовом 
- **Пустое значение URL/hostname**: выводится предупреждение, цель пропускается
- **Возврат в меню после добавления целей**: выбор 2 теперь возвращает результат (даже пустой массив)
- **Тесты без целей**:  проверяет  и завершает работу с ошибкой
- **Добавлены подсказки**: ввод имени цели и завершение пустой строкой / 0

## Что изменено

- : 
  -  — null-safe input, exit keywords, empty value guard, hints
  -  — choice 2 returns empty array with message
- : empty-target guard after 
- : token checks for new guard messages