### PR TITLE
chore: bump service.bat version to 1.0.5

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -1,5 +1,5 @@
 @echo off
-set "LOCAL_VERSION=1.0.4"
+set "LOCAL_VERSION=1.0.5"
 set "SERVICE_CONTROL=%~dp0tools\service-control.ps1"
 set "POWERSHELL=C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
 set "COMSPEC_TRUSTED=C:\Windows\System32\cmd.exe"

--- a/tests/validate_service_manager.py
+++ b/tests/validate_service_manager.py
@@ -27,7 +27,7 @@ def require(text: str, token: str, label: str) -> None:
 
 def main() -> int:
     service = SERVICE.read_text(encoding="utf-8-sig")
-    require(service, 'set "LOCAL_VERSION=1.0.4"', "service manager version")
+    require(service, 'set "LOCAL_VERSION=1.0.5"', "service manager version")
     if 'set "LOCAL_VERSION=2.0.2"' in service:
         fail("service.bat не должен показывать версию стороннего service manager")
     for token in [


### PR DESCRIPTION
В service.bat заголовок показывал v1.0.4 вместо v1.0.5.